### PR TITLE
LPS-123762 Apply this fix to depot

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/_variables.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/_variables.scss
@@ -16,7 +16,7 @@ $managementBarHeight: 64px;
 $multiPanelSidebarButtonWidth: 40px;
 $multiPanelSidebarContentWidth: 340px;
 $toolbarHeight: 64px;
-$publicationsHeight: 24px;
+$menuIndicatorHeight: 24px;
 
 // z-indexes, ordered numerically.
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/_variables.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/_variables.scss
@@ -16,6 +16,7 @@ $managementBarHeight: 64px;
 $multiPanelSidebarButtonWidth: 40px;
 $multiPanelSidebarContentWidth: 340px;
 $toolbarHeight: 64px;
+$publicationsHeight: 24px;
 
 // z-indexes, ordered numerically.
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_fieldset_modal.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_fieldset_modal.scss
@@ -3,7 +3,7 @@ body.has-control-menu .fieldset-modal {
 		overflow-x: hidden;
 	}
 
-	.multi-panel-sidebar {
+	.multi-panel-sidebar.multi-panel-sidebar.multi-panel-sidebar.multi-panel-sidebar {
 		position: absolute;
 		top: 0;
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_multi_panel_sidebar.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_multi_panel_sidebar.scss
@@ -100,24 +100,25 @@ $zIndexContent: 0;
 		}
 	}
 
-	&.publications-enabled {
-		height: calc(100vh - #{$toolbarHeight + $publicationsHeight});
-		top: $toolbarHeight + $publicationsHeight;
+	&.menu-indicator-enabled {
+		height: calc(100vh - #{$toolbarHeight + $menuIndicatorHeight});
+		top: $toolbarHeight + $menuIndicatorHeight;
 
 		body.has-control-menu & {
 			height: calc(
 				100vh - #{$controlMenuHeight + $managementBarHeight +
-					$publicationsHeight}
+					$menuIndicatorHeight}
 			);
-			top: $controlMenuHeight + $managementBarHeight + $publicationsHeight;
+			top: $controlMenuHeight + $managementBarHeight +
+				$menuIndicatorHeight;
 
 			@include media-breakpoint-up(lg) {
 				height: calc(
 					100vh - #{$desktopControlMenuHeight + $toolbarHeight +
-						$publicationsHeight}
+						$menuIndicatorHeight}
 				);
 				top: $desktopControlMenuHeight + $toolbarHeight +
-					$publicationsHeight;
+					$menuIndicatorHeight;
 			}
 		}
 	}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_multi_panel_sidebar.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/css/components/_multi_panel_sidebar.scss
@@ -100,6 +100,28 @@ $zIndexContent: 0;
 		}
 	}
 
+	&.publications-enabled {
+		height: calc(100vh - #{$toolbarHeight + $publicationsHeight});
+		top: $toolbarHeight + $publicationsHeight;
+
+		body.has-control-menu & {
+			height: calc(
+				100vh - #{$controlMenuHeight + $managementBarHeight +
+					$publicationsHeight}
+			);
+			top: $controlMenuHeight + $managementBarHeight + $publicationsHeight;
+
+			@include media-breakpoint-up(lg) {
+				height: calc(
+					100vh - #{$desktopControlMenuHeight + $toolbarHeight +
+						$publicationsHeight}
+				);
+				top: $desktopControlMenuHeight + $toolbarHeight +
+					$publicationsHeight;
+			}
+		}
+	}
+
 	&-dark {
 		& .multi-panel-sidebar-buttons {
 			background-color: $gray-800;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebar.es.js
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebar.es.js
@@ -195,8 +195,11 @@ export default function MultiPanelSidebar({
 					'multi-panel-sidebar',
 					`multi-panel-sidebar-${variant}`,
 					{
-						'publications-enabled': document.querySelector(
-							'.change-tracking-indicator'
+						'menu-indicator-enabled': document.querySelector(
+							[
+								'.change-tracking-indicator',
+								'.staging-indicator',
+							].join(',')
 						),
 					}
 				)}


### PR DESCRIPTION
Hi @liferay-app-builder,

On this pull request, I try to check if the publications or depot staging indicator 
to avoid the app builder sidebar being misaligned in DM > Documents Type New.

**Test plans:**

1. Enable:
	- Asset Library staging: 
		1. Create FeatureFlag in `bundles/osgi/configs` `echo enabled=B\"true\" > com.liferay.depot.web.internal.configuration.FFDepotStagingConfiguration.config`
		2. Global menu > Aplications > Asset Libraries
		3. Click on the [ + ] New
		4. Enter a name, save and go back with the [<]
		5. Click in the name of the new asset library
		6. Click in the bottom PUBLISHING > staging button
		7. Select `Local Live` and save

	- Publications: 
		1. Global menu > Aplications > PUBLICATIONS > Settings
		2. Enable and Save.

2. View:
	- Asset Library staging: 
		1. Global menu > Aplications > Asset Libraries > Click in the card name
		2. Click in Documents and Media 
		3. Click in Documents Type tan > [ + ] New
	
	- Publicatons: Go to Site menu > Content & Data > Documents and Media > Documents Type > [ + ] New

Note: Publications and Asset Library staging doesn´t work at the same time.

**Before the fix:**


Asset Library staging:
![image](https://user-images.githubusercontent.com/67901/100226493-1ef89a80-2f20-11eb-95f7-d1f36fb407d7.png)


Publications:
![image](https://user-images.githubusercontent.com/67901/100226560-3768b500-2f20-11eb-9e3a-bf40922ad684.png)


**After the fix:**

Asset Library staging:
![image](https://user-images.githubusercontent.com/67901/100227388-5e73b680-2f21-11eb-8955-71a0260e1b1b.png)

Publications:
![image](https://user-images.githubusercontent.com/67901/100227547-98dd5380-2f21-11eb-8388-4c3654d9e079.png)

Kindly request your review and let me know if any further changes are required.


**LPS:** https://issues.liferay.com/browse/LPS-123762