### PR TITLE
LPS-123867 Fields normalization is no longer needed when DataDefinition is updated

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/DataDefinitionResourceImpl.java
@@ -599,11 +599,6 @@ public class DataDefinitionResourceImpl
 							DataDefinitionField.class));
 				}
 
-				_normalize(
-					existingDataDefinition.getAvailableLanguageIds(),
-					nestedDataDefinitionFields,
-					dataDefinition.getDefaultLanguageId());
-
 				dataDefinitionField.setNestedDataDefinitionFields(
 					nestedDataDefinitionFields);
 			}
@@ -1018,66 +1013,6 @@ public class DataDefinitionResourceImpl
 			ResourceBundleUtil.getBundle(
 				"content.Language", locale, ddmFormFieldType.getClass()),
 			_portal.getResourceBundle(locale));
-	}
-
-	private void _normalize(
-		String[] availableLanguageIds,
-		DataDefinitionField[] dataDefinitionFields, String defaultLanguageId) {
-
-		for (DataDefinitionField dataDefinitionField : dataDefinitionFields) {
-			Map<String, Object> customProperties =
-				dataDefinitionField.getCustomProperties();
-
-			if (MapUtil.isNotEmpty(customProperties)) {
-				_normalize(
-					availableLanguageIds, defaultLanguageId,
-					(Map)customProperties.get("options"));
-				_normalize(
-					availableLanguageIds, defaultLanguageId,
-					(Map)customProperties.get("placeholder"));
-				_normalize(
-					availableLanguageIds, defaultLanguageId,
-					(Map)customProperties.get("tooltip"));
-			}
-
-			_normalize(
-				availableLanguageIds, defaultLanguageId,
-				dataDefinitionField.getDefaultValue());
-			_normalize(
-				availableLanguageIds, defaultLanguageId,
-				dataDefinitionField.getLabel());
-
-			if (ArrayUtil.isNotEmpty(
-					dataDefinitionField.getNestedDataDefinitionFields())) {
-
-				_normalize(
-					availableLanguageIds,
-					dataDefinitionField.getNestedDataDefinitionFields(),
-					defaultLanguageId);
-			}
-
-			_normalize(
-				availableLanguageIds, defaultLanguageId,
-				dataDefinitionField.getTip());
-		}
-	}
-
-	private void _normalize(
-		String[] availableLanguageIds, String defaultLanguageId,
-		Map<String, Object> map) {
-
-		if (MapUtil.isEmpty(map)) {
-			return;
-		}
-
-		for (String languageId : availableLanguageIds) {
-			map.putIfAbsent(languageId, map.get(defaultLanguageId));
-		}
-
-		Set<Map.Entry<String, Object>> entries = map.entrySet();
-
-		entries.removeIf(
-			entry -> !ArrayUtil.contains(availableLanguageIds, entry.getKey()));
 	}
 
 	private void _removeFieldsFromDataLayout(


### PR DESCRIPTION
The Normalization Function is no longer needed, since we don't need parse the availableLanguageIds through fields properties, like ```label```, ```options```, ```placeholder``` and others.

Old behavior:

I have 3 availableLanguageIds: "en_US", "pt_BR", "es_ES"

and for each language I needed to do something like:

Before normalize:
```
{
  "label": {
    "en_US": "name",
  }
}
```
after normalize
```
{
  "label": {
    "en_US": "name",
    "pt_BR": "name",
    "es_ES": "name"
  }
}
```

And now if we receive:

```
{
  "label": {
    "en_US": "name",
  }
}
```

Will be saved 
```
{
  "label": {
    "en_US": "name",
  }
}
```

This changes is required because now the DataDefinition can have only "en_US" as availableLanguageIds, but contain a Field (Like a FieldSet) that contains others translation, like "en_US", "pt_BR", "es_ES".

So, this way, without the normalize function the FieldSet languages will be preserved.

ℹ️ This PR is also Blocked, because of 2 Impedibugs present on Master, and the idea is this PR to move-on after both impedi bugs be fixed
 
If you guys, need any help to understand what's going on, just contact me!
